### PR TITLE
Ignore external folder and improve code quality

### DIFF
--- a/+run/r_MAST.m
+++ b/+run/r_MAST.m
@@ -5,6 +5,7 @@ if nargin < 3, genelist = (1:size(X, 1))'; end
 T = [];
 isdebug = false;
 oldpth = pwd();
+cleanupObj = onCleanup(@() cd(oldpth));
 [isok, msg, codepath] = commoncheck_R('R_MAST');
 if ~isok, error(msg); end
 if ~isempty(wkdir) && isfolder(wkdir), cd(wkdir); end
@@ -50,5 +51,4 @@ T = addvars(T, avg_1, 'After', 'abs_log2FC');
 T = sortrows(T, 'abs_log2FC', 'descend');
 T = sortrows(T, 'p_val_adj', 'ascend');
 if ~isdebug, pkg.i_deletefiles(tmpfilelist); end
-cd(oldpth);
 end

--- a/+run/r_decontX.m
+++ b/+run/r_decontX.m
@@ -8,6 +8,7 @@ if nargin < 2, wkdir = tempdir; end
 if nargin < 3, isdebug = true; end
 
 oldpth = pwd();
+cleanupObj = onCleanup(@() cd(oldpth));
 [isok, msg, codepath] = commoncheck_R('R_decontX');
 
 if ~isok, error(msg); end
@@ -37,7 +38,7 @@ outputfile2 = fullfile(codepath,'output.h5');
 if exist(outputfile1, 'file')
    outputfile = outputfile1;
 else
-    if exist(outputfile1, 'file')
+    if exist(outputfile2, 'file')
         outputfile = outputfile2;
     else
         error('output.h5 missing.');
@@ -48,5 +49,4 @@ end
     contamination = h5read(outputfile, '/contamination');
 
 if ~isdebug, pkg.i_deletefiles(tmpfilelist); end
-cd(oldpth);
 end

--- a/+run/r_harmony.m
+++ b/+run/r_harmony.m
@@ -9,6 +9,7 @@ end
 if isempty(wkdir), wkdir = tempdir; end
 
 oldpth = pwd();
+cleanupObj = onCleanup(@() cd(oldpth));
 [isok, msg, codepth] = commoncheck_R('R_harmony');
 if ~isok, error(msg);
     return;
@@ -46,6 +47,5 @@ end
 
 
 if ~isdebug, pkg.i_deletefiles(tmpfilelist); end
-cd(oldpth);
 
 end

--- a/sc_deg.m
+++ b/sc_deg.m
@@ -102,9 +102,7 @@ function [T, Tup, Tdn] = sc_deg(X, Y, genelist, methodid, ...
     
     % Create results table
 
-    avg_log2FC = log2(avg_1) - log2(avg_2);
-    %avg_log2FC(avg_log2FC==Inf) = 1e99;
-    %avg_log2FC(avg_log2FC==-Inf) = -1e99;
+    avg_log2FC = log2(avg_1 + eps) - log2(avg_2 + eps);
     abs_log2FC = abs(avg_log2FC);
     T = table(gene, p_val, avg_log2FC, abs_log2FC, avg_1, ...
                 avg_2, pct_1, pct_2, p_val_adj, stats);

--- a/sc_mergedata.m
+++ b/sc_mergedata.m
@@ -15,8 +15,13 @@ switch lower(method)
         [genelist] = union(genelist1, genelist2, 'stable');
         [~, i] = ismember(genelist1, genelist);
         [~, j] = ismember(genelist2, genelist);
-        X1a = zeros(length(genelist), size(X1, 2));
-        X2a = zeros(length(genelist), size(X2, 2));
+        if issparse(X1) || issparse(X2)
+            X1a = sparse(length(genelist), size(X1, 2));
+            X2a = sparse(length(genelist), size(X2, 2));
+        else
+            X1a = zeros(length(genelist), size(X1, 2));
+            X2a = zeros(length(genelist), size(X2, 2));
+        end
         X1a(i, :) = X1;
         X2a(j, :) = X2;
 end

--- a/toolbox.ignore
+++ b/toolbox.ignore
@@ -32,3 +32,5 @@ docs
 **/.buildtool/**/*
 **/*.asv
 .git
+external
+external/**/*


### PR DESCRIPTION
This change addresses the user's request to ignore the 'external' folder while also performing a comprehensive code quality check. 

Key changes include:
1. **Toolbox Configuration:** Updated `toolbox.ignore` to exclude the `external/` directory from toolbox packaging.
2. **Robustness:** Replaced manual directory restoration with `onCleanup` in several `+run/` files to ensure the working directory is restored even after errors.
3. **Bug Fixes:** Corrected a logic error in `+run/r_decontX.m` that misidentified the output file path.
4. **Memory Optimization:** Modified `sc_mergedata.m` to use sparse matrices when merging datasets if the input is sparse, avoiding potential OOM errors.
5. **Numerical Stability:** Updated `sc_deg.m` to handle zero expression values safely in log-fold change calculations.

---
*PR created automatically by Jules for task [2133336863509729445](https://jules.google.com/task/2133336863509729445) started by @jamesjcai*